### PR TITLE
Fix a few typos and ensure ndk gets copied into toolchain

### DIFF
--- a/build/Linux/build-corelibs.sh
+++ b/build/Linux/build-corelibs.sh
@@ -68,9 +68,6 @@ do
             -DLIBXML2_INCLUDE_DIR=$sysroot/usr/include/libxml2
 
         cmake --build $foundation_build_dir
-
-        # Undo those nasty changes
-        unlink $SYSROOT/usr/include/curl/curl
     popd
 
     pushd $xctest_build_dir
@@ -99,4 +96,12 @@ do
     cmake --build $dispatch_build_dir --target install
     cmake --build $foundation_build_dir --target install
     cmake --build $xctest_build_dir --target install
+done
+
+for arch in "${!abis[@]}"
+do
+  sysroot=$STANDALONE_TOOLCHAIN/$arch/sysroot
+
+  # Undo those nasty changes
+  unlink $sysroot/usr/include/curl/curl
 done

--- a/build/Linux/collect.sh
+++ b/build/Linux/collect.sh
@@ -9,7 +9,7 @@ declare -A icu_abis
 declare -A swift_archs
 
 swift_archs=(["arm64"]="aarch64" ["arm"]="armv7" ["x86_64"]="x86_64")
-abis=(["arm64"]="arm64-v8a" ["arm"]="armeabi-v7a" ["x86_64"]="x86_64")
+icu_abis=(["arm64"]="arm64-v8a" ["arm"]="armeabi-v7a" ["x86_64"]="x86_64")
 
 for arch in "${!swift_archs[@]}"
 do
@@ -19,10 +19,10 @@ do
     dst_libs=$DST_ROOT/swift-nightly-install/usr/lib/swift/android/$swift_arch
     sysroot=$STANDALONE_TOOLCHAIN/$arch/sysroot
     icu_libs=$ICU_LIBS/$abi
-    
+
     cp $icu_libs/*.so $dst_libs
 
-    rsync -av $ANDROID_NDK17/sources/cxx-stl/llvm-libc++/libs/$abi/libc++_shared.so $SWIFT_LIB
+    rsync -av $ANDROID_NDK17/sources/cxx-stl/llvm-libc++/libs/$abi/libc++_shared.so $dst_libs
     rsync -av $icu_libs/libicu{uc,i18n,data}swift.so $dst_libs
     rsync -av $sysroot/usr/lib/libxml2.* $dst_libs
     rsync -av $sysroot/usr/lib/libcurl.* $dst_libs


### PR DESCRIPTION
Hi!

I spent a few hours last week trying to build the toolchain for swift5 and ran into issues with the build process due to some typos and other bugs. These changes are my attempts at fixing them. They have resulted in a successfully built swift5 toolchain...so far. I'm still in the process of testing our android app with this toolchain, but I told @zayass I'd pull request these changes.
