### PR TITLE
Fix syntax error at python3

### DIFF
--- a/src/tools/bin/swift-android
+++ b/src/tools/bin/swift-android
@@ -40,7 +40,7 @@ def link(version):
 
     try:
         os.symlink(src, dst)
-    except OSError, e:
+    except OSError as e:
         if e.errno == errno.EEXIST:
             os.remove(dst)
             os.symlink(src, dst)


### PR DESCRIPTION
Python3 does not accept `except OSError, e:` syntax. Instead, we can use `as` keyword.