### PR TITLE
Release 6.3

### DIFF
--- a/.github/workflows/build-android-toolchain.yml
+++ b/.github/workflows/build-android-toolchain.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  SWIFT_VERSION: swift-6.2.1-RELEASE
+  SWIFT_VERSION: swift-6.3-RELEASE
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Fork of the official Swift SDK for Android that includes Readdle's patches. This
 
 Prebuilt SDKs are located on [GitHub Releases](https://github.com/readdle/swift-android-toolchain/releases).
 
-1. Install Swift toolchain 6.2.1 with [swiftly](https://www.swift.org/install/)
+1. Install Swift toolchain 6.3 with [swiftly](https://www.swift.org/install/)
 
 ```
-swiftly install 6.2.1
+swiftly install 6.3
 ```
 
 2. Install Android NDK 27d
@@ -21,9 +21,9 @@ $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "ndk;27.3.13750724"
 3. Install Readdle Swift Android SDK
 
 ```
-swift sdk install https://github.com/readdle/swift-android-toolchain/releases/download/6.2-r1/readdle-swift-6.2.1-RELEASE_android.artifactbundle.tar.gz --checksum 2057ecd9cf71fcd9beaded08d370f4815f867983c073f2d0010796aefdf8c2f1
+swift sdk install https://github.com/readdle/swift-android-toolchain/releases/download/6.3-r1/readdle-swift-6.3-RELEASE_android.artifactbundle.tar.gz --checksum <CHECKSUM>
 export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.3.13750724
-~/Library/org.swift.swiftpm/swift-sdks/readdle-swift-6.2.1-RELEASE_android.artifactbundle/swift-android/scripts/setup-android-sdk.sh
+~/Library/org.swift.swiftpm/swift-sdks/readdle-swift-6.3-RELEASE_android.artifactbundle/swift-android/scripts/setup-android-sdk.sh
 ```
 
 ## Build and test Swift packages on Android
@@ -103,7 +103,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.readdle.android.swift:gradle:6.2'
+        classpath 'com.readdle.android.swift:gradle:6.3'
     }
 }
 ```
@@ -130,12 +130,12 @@ The SDK can be built using Docker or locally on Ubuntu 24.04.
 
 ### Docker build
 ```
-./build-docker tag:swift-6.2.1-RELEASE ./output-dir
+./build-docker tag:swift-6.3-RELEASE ./output-dir
 ```
 
 ### Local build (Ubuntu 24.04)
 ```
-./build-local tag:swift-6.2.1-RELEASE ./output-dir
+./build-local tag:swift-6.3-RELEASE ./output-dir
 ```
 
 Both scripts accept a Swift version specifier and a working directory for the build output.

--- a/build-docker
+++ b/build-docker
@@ -61,6 +61,18 @@ perl -pi -g -we "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2i
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' ${WORKDIR}/source/swift-project/swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
 
+# Push trunk back to build against Android API 24 with NDK 28c
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_NDK_VERSION=android-ndk-r28c
+    ANDROID_API=24
+
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_decoding_packs.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering_packs.swift
+fi
+
 pushd ${WORKDIR}/source/swift-project
     # Apply patches (sub-repos were already reset above).
     for REPO in */; do

--- a/build-local
+++ b/build-local
@@ -24,6 +24,12 @@ BASEPATH=$(dirname $(realpath $0))
 cd ${BASEPATH}
 
 export SWIFT_VERSION=${1}
+
+# Push trunk back to build against Android API 24 with NDK 28c
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_NDK_VERSION=android-ndk-r28c
+    ANDROID_API=24
+fi
 # note that WORKDIR must not be under the current checkout or the patches will fail to apply
 WORKDIR=${2}
 if [[ "${WORKDIR}" == '' ]]; then
@@ -70,6 +76,15 @@ perl -pi -g -we "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2i
 
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' ${WORKDIR}/source/swift-project/swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
+
+# Disable failing trunk tests when building against NDK 28c
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_decoding_packs.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering_packs.swift
+fi
 
 mkdir -p ${WORKDIR}/products
 

--- a/patches/swift-corelibs-foundation/0016-fix-crash-in-redirect-callback-when-timeout-races.patch
+++ b/patches/swift-corelibs-foundation/0016-fix-crash-in-redirect-callback-when-timeout-races.patch
@@ -1,0 +1,32 @@
+From 28758fd9ce466e80b564d6f32bebcb24b48a60d8 Mon Sep 17 00:00:00 2001
+From: Yaroslav Biletskyi <ybiletskyi@readdle.com>
+Date: Wed, 15 Apr 2026 15:46:05 +0300
+Subject: [PATCH] Fix crash in redirect callback when timeout races with
+ redirect
+
+Replace fatalError with early return in didCompleteRedirectCallback
+when the timeout handler has already completed the task.
+---
+ .../URLSession/HTTP/HTTPURLProtocol.swift                   | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+index 90a19611..6c5be6cf 100644
+--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
++++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+@@ -702,7 +702,11 @@ fileprivate let userAgentString: String = {
+ extension _HTTPURLProtocol {
+     fileprivate func didCompleteRedirectCallback(_ request: URLRequest?) {
+         guard case .waitingForRedirectCompletionHandler(response: let response, bodyDataDrain: let bodyDataDrain) = self.internalState else {
+-            fatalError("Received callback for HTTP redirection, but we're not waiting for it. Was it called multiple times?")
++            // The timeout handler may have already transitioned the state
++            // away from .waitingForRedirectCompletionHandler (e.g. to
++            // .taskCompleted). In that case, the task is already finished
++            // and we should simply ignore this late callback.
++            return
+         }
+         // If the request is `nil`, we're supposed to treat the current response
+         // as the final response, i.e. not do any redirection.
+-- 
+2.50.1 (Apple Git-155)
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -495,6 +495,7 @@ for arch in $archs; do
             --host-test \
             --skip-test-linux \
             --skip-test-xctest --skip-test-foundation \
+            --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest \
             --build-swift-static-stdlib \
             --swift-install-components='compiler;clang-resource-dir-symlink;license;stdlib;sdk-overlay' \
             --install-swift \
@@ -513,6 +514,8 @@ for arch in $archs; do
         # the build directory, or else we get errors like:
         # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule
         rm -rf $ndk_installation/sysroot/usr/lib/swift/android
+        rm -rf $ndk_installation/sysroot/usr/lib/swift/../swift_static/android
+        rm -rf $ndk_installation/sysroot/usr/lib/swift/../../../swift-linux-x86_64/lib/swift{,_static}/android
     quiet_popd
     groupend
 done

--- a/scripts/fetch-source.sh
+++ b/scripts/fetch-source.sh
@@ -87,7 +87,7 @@ EOF
 
 # Defaults
 if [[ -z "${SWIFT_VERSION}" || ($SWIFT_VERSION != scheme:* && $SWIFT_VERSION != tag:*) ]]; then
-    SWIFT_VERSION=scheme:release/6.2
+    SWIFT_VERSION=scheme:release/6.3
 fi
 if [[ -z "${BORINGSSL_VERSION}" ]]; then
     BORINGSSL_VERSION=fips-20220613

--- a/scripts/toolchain-vars.sh
+++ b/scripts/toolchain-vars.sh
@@ -15,8 +15,8 @@
 # ===----------------------------------------------------------------------===
 
 # This script is meant to be sourced from another script that sets the
-# SWIFT_VERSION environment variable to one of "scheme:release/6.2" or
-# "tag:swift-6.2-RELEASE" and will get the latest builds for each build
+# SWIFT_VERSION environment variable to one of "scheme:release/6.3" or
+# "tag:swift-6.3-RELEASE" and will get the latest builds for each build
 # type.
 
 OS=$(echo $HOST_OS | tr -d '.')


### PR DESCRIPTION
Bump all version references from 6.2 to 6.3 and sync build scripts with upstream swift-docker changes while keeping Readdle patches on top. Upstream additions: trunk/dev NDK 28c support, skip-clean build flags, and extra sysroot cleanup after Swift build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades the Swift toolchain to 6.3 and changes build/NDK behavior for trunk/dev builds, which can affect SDK reproducibility and CI build outputs.
> 
> **Overview**
> Updates the Android Swift SDK release from **6.2.x to 6.3** across CI (`SWIFT_VERSION`), documentation (install URLs, Gradle plugin version), and source-fetch defaults (release branch `6.3`).
> 
> Syncs build scripts with upstream changes: trunk/dev builds now use **NDK `r28c` with Android API 24** and remove a small set of known-failing trunk tests, `build.sh` adds `--skip-clean-*` flags for faster/less destructive rebuilds, and performs additional sysroot cleanup after Swift builds.
> 
> Adds a new Foundation patch that avoids a crash by ignoring late redirect callbacks in `HTTPURLProtocol.didCompleteRedirectCallback` when a timeout has already completed the task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e77b673050d32a3181c9a5b20a3c3b31608313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->